### PR TITLE
Add second case to `choose ` and `multi_select ` macros, allowing for variables to be passed in that evaluate to slice-like types.

### DIFF
--- a/examples/setup_wizard.rs
+++ b/examples/setup_wizard.rs
@@ -37,19 +37,18 @@ fn main() {
         ["AWS", "Google Cloud", "Azure", "Digital Ocean", "None"]
     );
 
+    let choices = &[
+        "Rust",
+        "Python",
+        "JavaScript",
+        "Go",
+        "Java",
+        "C++",
+        "TypeScript",
+    ];
+
     // multi_select! macro - multiple choices
-    let languages = multi_select!(
-        "Programming languages used",
-        [
-            "Rust",
-            "Python",
-            "JavaScript",
-            "Go",
-            "Java",
-            "C++",
-            "TypeScript"
-        ]
-    );
+    let languages = multi_select!("Programming languages used", choices);
 
     let databases = multi_select!(
         "Databases needed",

--- a/src/core.rs
+++ b/src/core.rs
@@ -91,7 +91,7 @@ pub fn confirm(prompt: &str) -> bool {
 /// Pick one option from a list
 pub fn choose<T>(prompt: &str, choices: &[T]) -> T
 where
-    T: std::fmt::Display + Clone,
+    T: std::fmt::Display + Clone + AsRef<str>,
 {
     if choices.is_empty() {
         panic!("Cannot choose from empty list");
@@ -116,7 +116,7 @@ where
 /// Pick multiple options from a list
 pub fn multi_select<T>(prompt: &str, choices: &[T]) -> Vec<T>
 where
-    T: std::fmt::Display + Clone,
+    T: std::fmt::Display + Clone + AsRef<str>,
 {
     if choices.is_empty() {
         return Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,10 @@ macro_rules! choose {
     ($prompt:expr, [$($choice:expr),+ $(,)?]) => {
         $crate::choose($prompt, &[$($choice),+])
     };
+
+    ($prompt:expr, $choices:expr) => {
+        $crate::choose($prompt, $choices.as_ref())
+    };
 }
 
 #[macro_export]
@@ -102,6 +106,11 @@ macro_rules! multi_select {
     ($prompt:expr, [$($choice:expr),+ $(,)?]) => {
         $crate::multi_select($prompt, &[$($choice),+])
     };
+
+    ($prompt:expr, $choices:expr) => {
+        $crate::multi_select($prompt, $choices.as_ref())
+    };
+
 }
 
 /// Quick form macro for simple cases


### PR DESCRIPTION
Pretty much the title.   Only the code in those macros was changed, along with an example to show the passing of a `&[T]` type into the `multi_select` macro as a variable.

Edit:  recent commit makes change within `core.rs` for adding the `AsRef<str>` bound.

**PREVIOUS BEHAVIOR**
<img width="1325" height="436" alt="image" src="https://github.com/user-attachments/assets/59b6c670-abfe-46a7-a128-5be190d0fede" />

**NEW BEHAVIOR** (the error is gone)
<img width="1173" height="338" alt="image" src="https://github.com/user-attachments/assets/f720cae0-5043-44b4-a51a-5ab613b026e8" />
